### PR TITLE
Slot time fix

### DIFF
--- a/android/src/main/java/com/google/samples/apps/iosched/io/SessionsHandler.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/io/SessionsHandler.java
@@ -491,7 +491,10 @@ public class SessionsHandler extends JSONHandler {
                         .withValue(ScheduleContract.Sessions.SESSION_COLOR, color);
 
 
-                String blockId = ScheduleContract.Blocks.generateBlockId(sessionStartTime, sessionEndTime);
+                long blockStart = snapStartTime(sessionStartTime);
+                long blockEnd = snapEndTime(sessionEndTime);
+
+                String blockId = ScheduleContract.Blocks.generateBlockId(blockStart, blockEnd);
                 if (blockId != null && !blockIds.contains(blockId)) { // TODO add support for fetching blocks and inserting
                     String blockType;
                     String blockTitle;

--- a/android/src/main/java/com/google/samples/apps/iosched/model/ScheduleHelper.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/model/ScheduleHelper.java
@@ -52,7 +52,7 @@ public class ScheduleHelper {
         addBlocks(start, end, mutableItems, immutableItems);
         addSessions(start, end, mutableItems, immutableItems);
 
-        ArrayList<ScheduleItem> result = ScheduleItemHelper.processItems(mutableItems, immutableItems);
+        ArrayList<ScheduleItem> result = ScheduleItemHelper.processItemsNoFixes(mutableItems, immutableItems);
         if (BuildConfig.DEBUG || Log.isLoggable(TAG, Log.DEBUG)) {
             ScheduleItem previous = null;
             for (ScheduleItem item: result) {

--- a/android/src/main/java/com/google/samples/apps/iosched/model/ScheduleItemHelper.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/model/ScheduleItemHelper.java
@@ -16,6 +16,8 @@
 
 package com.google.samples.apps.iosched.model;
 
+import android.support.annotation.NonNull;
+
 import java.util.*;
 
 public class ScheduleItemHelper {
@@ -36,6 +38,13 @@ public class ScheduleItemHelper {
         // mark conflicting immutable:
         markConflicting(immutableItems);
 
+        ArrayList<ScheduleItem> result = processItemsNoFixes(mutableItems, immutableItems);
+
+        return result;
+    }
+
+    @NonNull
+    public static ArrayList<ScheduleItem> processItemsNoFixes(ArrayList<ScheduleItem> mutableItems, ArrayList<ScheduleItem> immutableItems) {
         ArrayList<ScheduleItem> result = new ArrayList<ScheduleItem>();
         result.addAll(immutableItems);
         result.addAll(mutableItems);
@@ -43,10 +52,11 @@ public class ScheduleItemHelper {
         Collections.sort(result, new Comparator<ScheduleItem>() {
             @Override
             public int compare(ScheduleItem lhs, ScheduleItem rhs) {
-                return lhs.startTime < rhs.startTime ? -1 : 1;
+                return lhs.startTime < rhs.startTime ||
+                        (lhs.type == ScheduleItem.FREE && lhs.startTime == rhs.startTime )
+                        ? -1 : 1;
             }
         });
-
         return result;
     }
 


### PR DESCRIPTION
Makes all talks starting at same time appear as one slot. Fixes UI when more than one slot is starred, but might be room for improvement here - removing header on the starred times to not have it repeated for instance? see picture
<img width="480" alt="screen shot 2016-08-31 at 23 09 46" src="https://cloud.githubusercontent.com/assets/85048/18146481/3a1084c2-6fd0-11e6-883a-335db95cfddd.png">
