### PR TITLE
Hide header of selected talks to not expose clickable header that lis…

### DIFF
--- a/android/src/main/java/com/google/samples/apps/iosched/myschedule/MyScheduleAdapter.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/myschedule/MyScheduleAdapter.java
@@ -328,7 +328,8 @@ public class MyScheduleAdapter implements ListAdapter, AbsListView.RecyclerListe
                 holder.description.setTextColor(mColorConflict);
                 setUriClickable(holder.touchArea, sessionUri);
             } else {
-                holder.startTime.setVisibility(View.VISIBLE);
+                //holder.startTime.setVisibility(View.VISIBLE);
+                holder.startTime.setVisibility(View.GONE);
                 setUriClickable(holder.startTime,
                         ScheduleContract.Sessions.buildUnscheduledSessionsInInterval(
                                 item.startTime, item.endTime));


### PR DESCRIPTION
…ts only talks in that timeslot (confuses user)
